### PR TITLE
v0.2.22

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -109,7 +109,7 @@
     "crypto",
     "proto"
   ]
-  revision = "2fd34be96083e5247afa4b44cff02ecdac106eb5"
+  revision = "cc257f4b1af2db6e86878bb0e5ad210c1deb18dd"
 
 [[projects]]
   name = "go.uber.org/atomic"

--- a/basedef/basedef.go
+++ b/basedef/basedef.go
@@ -4,4 +4,4 @@ package basedef
 const JARVISNODETYPE = "jarvisshell"
 
 // VERSION - version
-const VERSION = "0.2.21"
+const VERSION = "0.2.22"


### PR DESCRIPTION
- updated jarviscore to v0.7.46
- optimized the retry of the connection failed node